### PR TITLE
CommitOperation: reset SVN client after dispose

### DIFF
--- a/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/operations/CommitOperation.java
+++ b/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/operations/CommitOperation.java
@@ -80,30 +80,30 @@ public class CommitOperation extends SVNOperation {
 			}
         	if (resourcesToDelete.length > 0) {
 				ISVNClientAdapter svnDeleteClient = null; // use an adapter that will log to console
-				Map<SVNTeamProvider, List<IResource>> table = getProviderMapping(resourcesToDelete);
-				if (table.get(null) != null) {
-					throw new SVNException(Policy.bind("RepositoryManager.addErrorNotAssociated"));  //$NON-NLS-1$
-				}
-				Set<SVNTeamProvider> keySet = table.keySet();
-				for (SVNTeamProvider provider : keySet) {
-					List<IResource> list = table.get(provider);
-					File[] files = new File[list.size()];
-					int i=0;
-					for (IResource resource : list) {
-						ISVNLocalResource svnResource = SVNWorkspaceRoot.getSVNResourceFor(resource);
-						if (svnDeleteClient == null)
-						    svnDeleteClient = svnResource.getRepository().getSVNClient();
-						files[i] = svnResource.getFile();
-						i++;
+				try {
+					Map<SVNTeamProvider, List<IResource>> table = getProviderMapping(resourcesToDelete);
+					if (table.get(null) != null) {
+						throw new SVNException(Policy.bind("RepositoryManager.addErrorNotAssociated"));  //$NON-NLS-1$
 					}
-					try {
+					Set<SVNTeamProvider> keySet = table.keySet();
+					for (SVNTeamProvider provider : keySet) {
+						List<IResource> list = table.get(provider);
+						File[] files = new File[list.size()];
+						int i=0;
+						for (IResource resource : list) {
+							ISVNLocalResource svnResource = SVNWorkspaceRoot.getSVNResourceFor(resource);
+							if (svnDeleteClient == null)
+								svnDeleteClient = svnResource.getRepository().getSVNClient();
+							files[i] = svnResource.getFile();
+							i++;
+						}
 						svnDeleteClient.remove(files, true);
-					} catch (SVNClientException e) {
-						throw new TeamException(e.getMessage());
-					} finally {
-						SVNProviderPlugin.getPlugin().getSVNClientManager().returnSVNClient(svnDeleteClient);
 					}
-				}						
+				} catch (SVNClientException e) {
+					throw new TeamException(e.getMessage());
+				} finally {
+					SVNProviderPlugin.getPlugin().getSVNClientManager().returnSVNClient(svnDeleteClient);
+				}
 			}
         	setAtomicCommitMode();
         	Map<ProjectAndRepository, List<IResource>> table = getCommitProviderMapping(resourcesToCommit);


### PR DESCRIPTION
CommitOperations allow for committing files from several
different SVN Team providers at the same time. This is for
example useful to commit from multiple working copies at the same
time. When doing this, we have to determine for each resource to
be committed, to which SVN Team provider it belongs and add it to
this provider's transaction. For each of these providers, we also
have to get a different SVN client, as one client cannot handle
multiple repositories.

When we try to delete files from different providers, we get the
set of providers for the files to be committed. Afterwards, we
iterate through each provider, get an SVN client and then commit
the files that belong to this specific provider. After each
iteration, we dispose the SVN client again.

But in fact, we do not reset the SVN client to `null`, so we will
never retrieve the client for following providers. As we call
`dispose` after each iteration, this will lead to a double free
error in C++ code. The issue can be reproduced by commiting two
_missing_ (not deleted) files from two different repositories at
once.

Fix the issue by resetting the SVN client to `null` after each
iteration.