### PR TITLE
throw a more specific exception on malformed project reference strings

### DIFF
--- a/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/SVNProjectSetCapability.java
+++ b/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/SVNProjectSetCapability.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
 
 import org.eclipse.core.resources.IProject;
@@ -133,17 +134,20 @@ public class SVNProjectSetCapability extends ProjectSetCapability {
             String[] referenceStrings, Map<IProject, LoadInfo> infoMap) throws SVNException {
         Collection<IProject> result = new ArrayList<IProject>();
         for (String referenceString : referenceStrings) {
-            StringTokenizer tokenizer = new StringTokenizer(
-                    referenceString, ","); //$NON-NLS-1$
-            String version = tokenizer.nextToken();
-            // If this is a newer version, then ignore it
-            if (!version.equals("0.9.3")) { //$NON-NLS-1$
-                continue;
+            StringTokenizer tokenizer = new StringTokenizer(referenceString, ","); //$NON-NLS-1$
+            try {
+                String version = tokenizer.nextToken();
+                // If this is a newer version, then ignore it
+                if (!version.equals("0.9.3")) { //$NON-NLS-1$
+                    continue;
+                }
+                LoadInfo info = new LoadInfo(context, tokenizer);
+                IProject proj = info.getProject();
+                result.add(proj);
+                infoMap.put(proj, info);
+            } catch (NoSuchElementException e) {
+                throw new IllegalArgumentException("malformed project reference: " + referenceString, e); //$NON-NLS-1$
             }
-            LoadInfo info = new LoadInfo(context, tokenizer);
-            IProject proj = info.getProject();
-            result.add(proj);
-            infoMap.put(proj, info);
         }
         return (IProject[]) result.toArray(new IProject[result.size()]);
     }


### PR DESCRIPTION
We generate our project set file from SVN. On occasion the generated reference string is malformed like that:

`<project reference="0.9.3,https://host/svn/path/to/plugin"/>` (--> the plugin name is missing)

In that case the team project set import just throws the following error:

```
An internal error occurred during: "Importing project set...".

java.util.NoSuchElementException
	at java.util.StringTokenizer.nextToken(StringTokenizer.java:349)
	at org.tigris.subversion.subclipse.core.SVNProjectSetCapability$LoadInfo.<init>(SVNProjectSetCapability.java:213)
	at org.tigris.subversion.subclipse.core.SVNProjectSetCapability.asProjects(SVNProjectSetCapability.java:143)
	at org.tigris.subversion.subclipse.core.SVNProjectSetCapability.addToWorkspace(SVNProjectSetCapability.java:107)
	at org.eclipse.team.internal.ui.ProjectSetImporter.importProjectSet(ProjectSetImporter.java:109)
	at org.eclipse.team.internal.ui.ProjectSetImporter.importProjectSet(ProjectSetImporter.java:67)
	at org.eclipse.team.internal.ui.wizards.ImportProjectSetOperation.runForFile(ImportProjectSetOperation.java:84)
	at org.eclipse.team.internal.ui.wizards.ImportProjectSetOperation.run(ImportProjectSetOperation.java:100)
	at org.eclipse.team.internal.ui.actions.JobRunnableContext.run(JobRunnableContext.java:151)
	at org.eclipse.team.internal.ui.actions.JobRunnableContext$ResourceJob.runInWorkspace(JobRunnableContext.java:76)
	at org.eclipse.core.internal.resources.InternalWorkspaceJob.run(InternalWorkspaceJob.java:39)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:55)
```

With my changes the following error would be shown:

```
An internal error occurred during: "Importing project set...".
java.lang.IllegalArgumentException: malformed project reference: 0.9.3,https://host/svn/path/to/plugin
	...
```
