### PR TITLE
Fix could not auto-share project error when creating new projects

### DIFF
--- a/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/resourcesListeners/FileModificationManager.java
+++ b/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/resourcesListeners/FileModificationManager.java
@@ -298,7 +298,7 @@ public class FileModificationManager implements IResourceChangeListener, ISavePa
 			client = SVNProviderPlugin.getPlugin().getSVNClient();
 			SVNProviderPlugin.disableConsoleLogging();
 			ISVNInfo info = client.getInfoFromWorkingCopy(project.getLocation().toFile());
-			if (info != null) {
+			if (info != null && info.getRepository() != null) {
 				SVNTeamProviderType.getAutoShareJob().share(project);
 			}
 		} catch (Exception e) {}


### PR DESCRIPTION
Fixes #50 - if the returned ISVNInfo is not null, check also that
the repository is also not null. This prevents attempts to auto
share a project that is unversioned because in thoses cases, the
ISVNInfo that is returned is an SVNInfoUnversioned.

Signed-off-by: Mat Booth <mat.booth@redhat.com>