### PR TITLE
add peg revision to URL in pinned externals

### DIFF
--- a/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/SVNExternal.java
+++ b/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/SVNExternal.java
@@ -142,7 +142,7 @@ public class SVNExternal {
 			return propertyLine;
 		}
 		else {
-			return "-r" + revision + " " + url + " " + folder;
+			return "-r" + revision + " " + url + "@" + revision + " " + folder;
 		}
 	}
 	


### PR DESCRIPTION
Add a peg revision to external URLs when externals are fixed to a
specific revision during copies (Branch/Tag).

Externals fixed to a revision should carry a peg revision because the
item pointed to could disappear from the HEAD revision at any point in
time.