### PR TITLE
Ignore files in symlinked directories

### DIFF
--- a/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/ISVNLocalResource.java
+++ b/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/ISVNLocalResource.java
@@ -79,7 +79,13 @@ public interface ISVNLocalResource extends ISVNResource, IAdaptable {
   /** @return the parent of this local resource */
   public ISVNLocalFolder getParent();
 
-  /** @return the underlaying resource */
+  /**
+   * @return true if any parent is a symbolic link
+   * @throws SVNException
+   */
+  public boolean hasSymlinkParent() throws SVNException;
+  
+  /** @return the underlying resource */
   public IResource getIResource();
 
   /** @return the file corresponding to the resource */

--- a/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/resources/LocalResource.java
+++ b/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/resources/LocalResource.java
@@ -117,6 +117,9 @@ public abstract class LocalResource implements ISVNLocalResource, Comparable {
     if (isParentInSvnIgnore()) {
       return true;
     }
+    if (isParentSymlink()) {
+    	return true;
+    }
 
     LocalResourceStatus status = getStatusFromCache();
 
@@ -182,6 +185,20 @@ public abstract class LocalResource implements ISVNLocalResource, Comparable {
     }
     // It's not under svn:ignore (at least according to cached statuses)
     return false;
+  }
+  
+  /**
+   * Checks whether the parent is a symbolic link.
+   * 
+   * @return true if the parent is a symlink
+   * @throws SVNException
+   */
+  protected boolean isParentSymlink() throws SVNException {
+  	ISVNLocalFolder parent = getParent();
+  	if (parent != null) {
+  		return LocalResource.isSymLink(parent);
+  	}
+  	return false;
   }
 
   /* (non-Javadoc)

--- a/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/resources/LocalResource.java
+++ b/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/resources/LocalResource.java
@@ -11,6 +11,9 @@ package org.tigris.subversion.subclipse.core.resources;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -117,7 +120,7 @@ public abstract class LocalResource implements ISVNLocalResource, Comparable {
     if (isParentInSvnIgnore()) {
       return true;
     }
-    if (isParentSymlink()) {
+    if (hasSymlinkParent()) {
       return true;
     }
 
@@ -187,18 +190,23 @@ public abstract class LocalResource implements ISVNLocalResource, Comparable {
     return false;
   }
   
-  /**
-   * Checks whether the parent is a symbolic link.
-   * 
-   * @return true if the parent is a symlink
-   * @throws SVNException
+  /* (non-Javadoc)
+   * @see org.tigris.subversion.subclipse.core.ISVNLocalResource#hasSymlinkParent()
    */
-  protected boolean isParentSymlink() throws SVNException {
+  public boolean hasSymlinkParent() throws SVNException {
     ISVNLocalFolder parent = getParent();
-    if (parent != null) {
-      return LocalResource.isSymLink(parent);
+    if (parent == null) {
+    	return false;
     }
-    return false;
+    // stop checking at the project root (it may be a link or beneath one, which is fine)
+    if (parent.equals(getWorkspaceRoot().getLocalRoot())) {
+    	return false;
+    }
+    if (LocalResource.isSymLink(parent)) {
+    	return true;
+    }
+    // any other parent can be a symlink, too
+    return parent.hasSymlinkParent();
   }
 
   /* (non-Javadoc)
@@ -588,17 +596,13 @@ public abstract class LocalResource implements ISVNLocalResource, Comparable {
     return 23 * resource.getFullPath().hashCode();
   }
 
-  public static boolean isSymLink(ISVNLocalResource resource) {
-    File file = resource.getFile();
-    try {
-      if (!file.exists()) return true;
-      else {
-        String cnnpath = file.getCanonicalPath();
-        String abspath = file.getAbsolutePath();
-        return !abspath.equals(cnnpath);
-      }
-    } catch (IOException ex) {
-      return true;
-    }
-  }
+	public static boolean isSymLink(ISVNLocalResource resource) {
+		try {
+			File file = resource.getFile();
+			Path path = file.toPath();
+			return Files.isSymbolicLink(path);
+		} catch (InvalidPathException e) {
+			return false;
+		}
+	}
 }

--- a/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/resources/LocalResource.java
+++ b/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/resources/LocalResource.java
@@ -118,7 +118,7 @@ public abstract class LocalResource implements ISVNLocalResource, Comparable {
       return true;
     }
     if (isParentSymlink()) {
-    	return true;
+      return true;
     }
 
     LocalResourceStatus status = getStatusFromCache();
@@ -194,11 +194,11 @@ public abstract class LocalResource implements ISVNLocalResource, Comparable {
    * @throws SVNException
    */
   protected boolean isParentSymlink() throws SVNException {
-  	ISVNLocalFolder parent = getParent();
-  	if (parent != null) {
-  		return LocalResource.isSymLink(parent);
-  	}
-  	return false;
+    ISVNLocalFolder parent = getParent();
+    if (parent != null) {
+      return LocalResource.isSymLink(parent);
+    }
+    return false;
   }
 
   /* (non-Javadoc)


### PR DESCRIPTION
Fixes issue #119 by ignoring all files if their parent is a symbolic link.