### PR TITLE
made active changeset commit filter configurable

### DIFF
--- a/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/ISVNUIConstants.java
+++ b/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/ISVNUIConstants.java
@@ -293,6 +293,7 @@ public interface ISVNUIConstants {
   public final String PREF_ALLOW_COMMIT_WITH_ERRORS = "pref_commit_with_errors"; // $NON-NLS-1$
   public final String PREF_COMMIT_TO_TAGS_PATH_WITHOUT_WARNING =
       "pref_commit_to_tags_path_without_warning"; //$NON-NLS-1$
+  public final String PREF_COMMIT_ONLY_CHANGESET_RESOURCES = "pref_commit_only_changeset_resources"; //$NON-NLS-1$
 
   public final String PREF_UPDATE_TO_HEAD_IGNORE_EXTERNALS =
       "pref_update_to_head_ignore_externals"; //$NON-NLS-1$

--- a/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/SVNUIPreferenceInitializer.java
+++ b/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/SVNUIPreferenceInitializer.java
@@ -104,5 +104,7 @@ public class SVNUIPreferenceInitializer extends AbstractPreferenceInitializer {
     node.putInt(ISVNUIConstants.PREF_MENU_ICON_SET, ISVNUIConstants.MENU_ICON_SET_DEFAULT);
 
     node.putInt(ISVNUIConstants.PREF_COMMENTS_TO_SAVE, 10);
+
+    node.putBoolean(ISVNUIConstants.PREF_COMMIT_ONLY_CHANGESET_RESOURCES, true);
   }
 }

--- a/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/actions/CommitAction.java
+++ b/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/actions/CommitAction.java
@@ -524,6 +524,11 @@ public class CommitAction extends WorkbenchWindowAction {
   }
 
   private IResource[] getChangeSetResources(IResource[] allResources) {
+    IPreferenceStore preferenceStore = SVNUIPlugin.getPlugin().getPreferenceStore();
+    if (!preferenceStore.getBoolean(ISVNUIConstants.PREF_COMMIT_ONLY_CHANGESET_RESOURCES)) {
+      return allResources;
+    }
+    
     ActiveChangeSet changeSet = SVNProviderPlugin.getPlugin().getChangeSetManager().getDefaultSet();
     if (changeSet != null && !("<No Active Task>".equals(changeSet.getName()))) {
       List<IResource> changeSetResourceList = new ArrayList<IResource>();

--- a/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/messages.properties
+++ b/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/messages.properties
@@ -1148,6 +1148,7 @@ SVNPreferencePage.timeoutValue=&Communication timeout (in seconds):
 SVNPreferencesPage.0=Ignore changes to hidden resources
 SVNPreferencesPage.1=Ignore managed derived resources
 SVNPreferencesPage.2=Disable auto refresh of SVN status cache
+SVNPreferencesPage.3=Only commit resources from active change set
 SVNPreferencesPage.Timeout_must_be_a_number_2=Timeout must be a number
 SVNPreferencesPage.Timeout_must_not_be_negative_1=Timeout must not be negative
 SVNPreferencePage.configurationLocation=Configuration location :

--- a/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/preferences/SVNPreferencesPage.java
+++ b/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/preferences/SVNPreferencesPage.java
@@ -72,6 +72,7 @@ public class SVNPreferencesPage extends PreferencePage implements IWorkbenchPref
   private Button useDirectoryLocationRadio;
   private Text directoryLocationText;
   private Button browseConfigDirButton;
+  private Button commitOnlyChangesetResources;
 
   private Button quickDiffAnnotateYes;
   private Button quickDiffAnnotateNo;
@@ -213,6 +214,7 @@ public class SVNPreferencesPage extends PreferencePage implements IWorkbenchPref
 
     ignoreRefreshSvnStatusCache =
         createCheckBox(composite, Policy.bind("SVNPreferencesPage.2")); // $NON-NLS-1$
+    commitOnlyChangesetResources = createCheckBox(composite, Policy.bind("SVNPreferencesPage.3")); // $NON-NLS-1$
 
     createLabel(composite, "", 2); // $NON-NLS-1$
 
@@ -386,6 +388,8 @@ public class SVNPreferencesPage extends PreferencePage implements IWorkbenchPref
             .getPluginPreferences()
             .getBoolean(ISVNCoreConstants.PREF_IGNORE_REFRESH_SVN_STATUS_CACHE));
 
+    commitOnlyChangesetResources.setSelection(store.getBoolean(ISVNUIConstants.PREF_COMMIT_ONLY_CHANGESET_RESOURCES));
+
     removeOnReplace.setSelection(
         store.getBoolean(ISVNUIConstants.PREF_REMOVE_UNADDED_RESOURCES_ON_REPLACE));
 
@@ -498,6 +502,8 @@ public class SVNPreferencesPage extends PreferencePage implements IWorkbenchPref
         .setValue(
             ISVNCoreConstants.PREF_IGNORE_REFRESH_SVN_STATUS_CACHE,
             ignoreRefreshSvnStatusCache.getSelection());
+
+    store.setValue(ISVNUIConstants.PREF_COMMIT_ONLY_CHANGESET_RESOURCES, commitOnlyChangesetResources.getSelection());
 
     //		store.setValue(ISVNUIConstants.PREF_SHOW_UNADDED_RESOURCES_ON_COMMIT,
     // showUnadded.getSelection());


### PR DESCRIPTION
Added preference to allow committing resources from project/package
explorer that are not part of the active change set.

We recently updated from an ancient subclipse version and got confused by the "new" behavior of filtering the selected resources according to the active changeset (15277c19ab83059a9f796ec10db4b88a404d21c8).
I've added a preference to disable this filter (the default does not change the current behavior).