### PR TITLE
SVNPluginAction delegates not notified of selection change after first instance of commit dialog

### DIFF
--- a/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/actions/SVNPluginAction.java
+++ b/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/actions/SVNPluginAction.java
@@ -90,9 +90,6 @@ public class SVNPluginAction extends Action
         setImageDescriptor(desc);
       }
     }
-
-    // Give delegate a chance to adjust enable state
-    selectionChanged(StructuredSelection.EMPTY);
   }
 
   private static int getStyleFromElement(IConfigurationElement element) {

--- a/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/wizards/dialogs/SvnWizardCommitPage.java
+++ b/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/wizards/dialogs/SvnWizardCommitPage.java
@@ -387,6 +387,8 @@ public class SvnWizardCommitPage extends SvnWizardDialogPage {
               toolbarManager.add(new Separator());
               for (int i = 0; i < toolbarActions.length; i++) {
                 SVNPluginAction action = toolbarActions[i];
+                // Give delegate a chance to adjust enable state
+                action.selectionChanged(StructuredSelection.EMPTY);
                 toolbarManager.add(action);
               }
             }


### PR DESCRIPTION
SVNPluginAction delegates not notified of selection change after first instance of commit dialog

https://github.com/subclipse/subclipse/issues/278

* Move empty selection notification from the SVNPluginAction object instantiation, which only occurs on the first instance of the commit dialog, to the action's addition to the toolbar, which allows plugins to reset after subsequent commits. 