### PR TITLE
UI-Deadlock during commit of multiple files

### DIFF
--- a/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/subscriber/SVNSynchronizeOperation.java
+++ b/bundles/subclipse.ui/src/org/tigris/subversion/subclipse/ui/subscriber/SVNSynchronizeOperation.java
@@ -129,4 +129,20 @@ public abstract class SVNSynchronizeOperation extends SynchronizeModelOperation 
    */
   protected abstract void run(SVNTeamProvider provider, SyncInfoSet set, IProgressMonitor monitor)
       throws InvocationTargetException, InterruptedException;
+  
+  @Override
+  protected boolean canRunAsJob() {
+    return true;
+  }
+  
+  @Override
+  protected String getJobName() {
+    return Policy.bind("SynchronizeWizard.title");
+  }
+  
+  @Override
+  public boolean isUserInitiated() {
+    return false;
+  }
+  
 }


### PR DESCRIPTION
In case the progress-monitor-dialog of Eclipse (busyCursorWhile) is shown before the SVN-commit-dialog is opened the UI is not operable anymore due to 2 modal dialogs.
Running the SVNSynchronizeOperation as a job avoids a progress-monitor-dialog.