### PR TITLE
Return gracefully in LocalResource.isSymLink() if resource doesn't exist

### DIFF
--- a/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/resources/LocalResource.java
+++ b/bundles/subclipse.core/src/org/tigris/subversion/subclipse/core/resources/LocalResource.java
@@ -600,6 +600,9 @@ public abstract class LocalResource implements ISVNLocalResource, Comparable {
 
 	public static boolean isSymLink(ISVNLocalResource resource) {
 		IResource wsResource = resource.getIResource();
+		if (wsResource == null || !wsResource.exists()) {
+			return false;
+		}
 		Boolean isSymLink = getSymLinkSessionProperty(wsResource);
 		if (isSymLink != null) {
 			return isSymLink;
@@ -616,9 +619,6 @@ public abstract class LocalResource implements ISVNLocalResource, Comparable {
 	}
 
   private static Boolean getSymLinkSessionProperty(IResource resource) {
-    if (resource == null) {
-      return null;
-    }
     try {
       return (Boolean) resource.getSessionProperty(SVN_IS_SYM_LINK);
     } catch (CoreException e) {
@@ -628,12 +628,10 @@ public abstract class LocalResource implements ISVNLocalResource, Comparable {
   }
 
   private static void setSymLinkSessionProperty(IResource resource, Boolean isSymLink) {
-    if (resource != null) {
-      try {
-        resource.setSessionProperty(SVN_IS_SYM_LINK, isSymLink);
-      } catch (CoreException e) {
-        SVNProviderPlugin.log(IStatus.ERROR, e.getMessage(), e);
-      }
+    try {
+      resource.setSessionProperty(SVN_IS_SYM_LINK, isSymLink);
+    } catch (CoreException e) {
+      SVNProviderPlugin.log(IStatus.ERROR, e.getMessage(), e);
     }
   }
 }


### PR DESCRIPTION
This is a follow-up to b76c575781f6e3fbdf4611ba826c7bad5aa0d314, due to which the sym-link information is stored as a session property. In case the file doesn't exist (e.g. if it was removed after an SVN update), this now throws a ResourceException.

In addition to checking whether the resource is null, it should also be checked whether the resource exists. Given that a non-existing file can't be a symbolic link, it is sufficient to return early if either of those conditions are met.